### PR TITLE
Test on 0.4, 0.5, and nightly on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,7 @@
 language: julia
+notifications:
+  email: false
+julia:
+  - 0.4
+  - 0.5
+  - nightly


### PR DESCRIPTION
the default is to only test on release, which is 0.5 now
Julia 0.4 is still supported here according to REQUIRE
